### PR TITLE
Enable signal generator sync output after :SING command for scope and…

### DIFF
--- a/examples/keysight/freqresp_keysight.m
+++ b/examples/keysight/freqresp_keysight.m
@@ -92,6 +92,7 @@ elseif strcmpi(excit_param.type, 'sin')
         scpiset(fid_instr.osc, param, 'STOP', '');
         scpiget(fid_instr.osc, param, 'ADER');
         scpiset(fid_instr.osc, param, 'SING', '');
+        scpiset(fid_instr.gen, param, 'OUTP:SYNC', 'ON');
         
         fprintf('Acquiring...');
         

--- a/scpiget.m
+++ b/scpiget.m
@@ -17,7 +17,6 @@ if nargin < 4
     type = 'char';
 end
 
-%if ~contains(cmd, '?')
 if ~size(strfind(cmd, '?'),1)
     cmd = [cmd '?'];
 end

--- a/scpiget.m
+++ b/scpiget.m
@@ -17,7 +17,8 @@ if nargin < 4
     type = 'char';
 end
 
-if ~contains(cmd, '?')
+%if ~contains(cmd, '?')
+if ~size(strfind(cmd, '?'),1)
     cmd = [cmd '?'];
 end
 


### PR DESCRIPTION
… fix check on scpiget()

- After sending :SINGle command to the oscilloscope to arm the trigger f or next acquisition, the signal generator output was off, so the scope waited indefinitely for the end of an untriggered acquisition. Turning it (sync out) on after sending :SING command solved the problem
- scpiget() used "contains()" to ensure the requested command  has the symbol '?' (as in a query), but this function isn't available in Octave (just in MATLAB). A different check method was used to fix